### PR TITLE
Refine email provenance scoring interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/ae_finder/__init__.py
+++ b/ae_finder/__init__.py
@@ -1,0 +1,5 @@
+"""Core Academic Evidence Finder package."""
+
+from .provenance import ProvenanceScorer
+
+__all__ = ["ProvenanceScorer"]

--- a/ae_finder/provenance.py
+++ b/ae_finder/provenance.py
@@ -1,0 +1,65 @@
+"""Utilities for scoring provenance evidence from email metadata."""
+
+from email.utils import getaddresses
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
+
+
+class ProvenanceScorer:
+    """Score artifacts using email provenance information."""
+
+    EMAIL_HEADER_PRECEDENCE: Sequence[tuple[str, str]] = (
+        ("from", "From"),
+        ("sender", "Sender"),
+        ("reply-to", "Reply-To"),
+    )
+
+    def __init__(self, target_emails: Iterable[str], email_score: float = 1.0) -> None:
+        self._target_emails = {
+            self._normalize_email(email)
+            for email in target_emails
+            if email
+        }
+        self.email_score = email_score
+
+    @staticmethod
+    def _normalize_email(address: str) -> str:
+        return address.strip().lower()
+
+    @staticmethod
+    def _normalize_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
+        return {key.lower(): value for key, value in headers.items() if isinstance(value, str)}
+
+    def _score_email(self, headers: Mapping[str, str]) -> Tuple[float, Optional[str]]:
+        """Score email provenance headers.
+
+        Returns a tuple of the awarded score and an evidence note. The note documents
+        the precedence of headers examined and which header produced a match.
+        """
+
+        if not self._target_emails or not headers:
+            return 0.0, None
+
+        normalized_headers = self._normalize_headers(headers)
+        precedence_display = " > ".join(display for _, display in self.EMAIL_HEADER_PRECEDENCE)
+
+        for header_key, display_name in self.EMAIL_HEADER_PRECEDENCE:
+            candidate_values = []
+            if header_key in normalized_headers:
+                candidate_values.append(normalized_headers[header_key])
+            if header_key == "reply-to":
+                for alias in ("reply_to", "replyto"):
+                    if alias in normalized_headers:
+                        candidate_values.append(normalized_headers[alias])
+
+            for raw_value in candidate_values:
+                for _, address in getaddresses([raw_value]):
+                    normalized_address = self._normalize_email(address)
+                    if normalized_address and normalized_address in self._target_emails:
+                        note = (
+                            f"Matched {display_name} header ({normalized_address}) while "
+                            f"checking precedence {precedence_display}."
+                        )
+                        return self.email_score, note
+
+        return 0.0, None
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for Academic Evidence Finder."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/email_reply_to.json
+++ b/tests/fixtures/email_reply_to.json
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "Reply-To": "Professor Example <prof@example.edu>",
+    "Subject": "Updated syllabus"
+  }
+}

--- a/tests/fixtures/email_sender.json
+++ b/tests/fixtures/email_sender.json
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "Sender": "Department Bot <bot@example.edu>",
+    "List-Id": "updates.example.edu"
+  }
+}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,84 @@
+"""Tests for the email provenance scorer."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ae_finder.provenance import ProvenanceScorer
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    with (FIXTURE_DIR / name).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_score_email_prefers_from_header():
+    scorer = ProvenanceScorer(["author@example.edu"], email_score=2.0)
+    headers = {
+        "From": "Author Example <author@example.edu>",
+        "Sender": "Department Bot <bot@example.edu>",
+        "Reply-To": "assistant@example.edu",
+    }
+
+    score, note = scorer._score_email(headers)
+    assert score == pytest.approx(2.0)
+    assert note is not None
+    assert "From" in note
+    assert "From > Sender > Reply-To" in note
+
+
+def test_score_email_falls_back_to_sender_header(tmp_path: Path):
+    fixture = load_fixture("email_sender.json")
+    scorer = ProvenanceScorer(["bot@example.edu"])
+
+    score, note = scorer._score_email(fixture["headers"])
+
+    assert score == pytest.approx(1.0)
+    assert note is not None
+    assert "Sender" in note
+    assert "bot@example.edu" in note
+    assert "From > Sender > Reply-To" in note
+
+
+def test_score_email_falls_back_to_reply_to_header():
+    fixture = load_fixture("email_reply_to.json")
+    scorer = ProvenanceScorer(["prof@example.edu"])
+
+    score, note = scorer._score_email(fixture["headers"])
+
+    assert score == pytest.approx(1.0)
+    assert note is not None
+    assert "Reply-To" in note
+    assert "prof@example.edu" in note
+    assert "From > Sender > Reply-To" in note
+
+
+def test_score_email_ignores_non_matching_headers():
+    headers = {
+        "From": "Different Person <other@example.edu>",
+        "Sender": "Department Bot <bot@example.edu>",
+        "Reply-To": "Assistant Example <assistant@example.edu>",
+    }
+    scorer = ProvenanceScorer(["prof@example.edu"])
+
+    score, note = scorer._score_email(headers)
+
+    assert score == pytest.approx(0.0)
+    assert note is None
+
+
+def test_score_email_handles_aliases_for_reply_to():
+    headers = {
+        "reply_to": "Professor Example <prof@example.edu>",
+    }
+    scorer = ProvenanceScorer(["prof@example.edu"])
+
+    score, note = scorer._score_email(headers)
+
+    assert score == pytest.approx(1.0)
+    assert note is not None
+    assert "Reply-To" in note
+    assert "prof@example.edu" in note


### PR DESCRIPTION
## Summary
- refine the provenance email scorer to return a score/note tuple while preserving the From/Sender/Reply-To fallback order
- clarify the public package exports to include only the provenance scorer
- update provenance tests to assert the tuple interface and confirm precedence notes mention the matching header

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7006f827c832283a5d1092ab135f6