### PR TITLE
Update README with macOS Python 3 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Scan your computer for artifacts that support **Teaching, Service, Scholarship**
 
 ### Edgar GUI (The Fun Way)
 ```bash
-./setup_edgar.sh              # One-command setup
-python scripts/edgar_gui.py   # Launch the retro GUI
+./setup_edgar.sh              # One-command setup (macOS: run with `bash setup_edgar.sh` if needed)
+python3 scripts/edgar_gui.py  # Launch the retro GUI with the system Python 3
 ```
 
 ### Command Line (The Serious Way)
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-python scripts/scan.py --include ~/Documents --out results
+python3 -m pip install -r requirements.txt
+python3 scripts/scan.py --include ~/Documents --out results
 ```
 
 ## Features
@@ -62,8 +62,8 @@ python scripts/scan.py --include ~/Documents --out results
 ### Edgar GUI
 ```bash
 # Setup and launch Edgar
-./setup_edgar.sh
-python scripts/edgar_gui.py
+./setup_edgar.sh               # or `bash setup_edgar.sh` on macOS
+python3 scripts/edgar_gui.py
 
 # Then use the GUI to:
 # 1. Select scan mode (Pass 1, Pass 2, or Full)
@@ -76,32 +76,32 @@ python scripts/edgar_gui.py
 ### Two-Pass Command Line
 ```bash
 # Quick metadata-only scan
-python scripts/scan_optimized.py --pass1-only --include ~/Documents --out results
+python3 scripts/scan_optimized.py --pass1-only --include ~/Documents --out results
 
 # Review results, then run detailed analysis on specific categories
-python scripts/scan_optimized.py --categories scholarship teaching --include ~/Documents --out results
+python3 scripts/scan_optimized.py --categories scholarship teaching --include ~/Documents --out results
 
 # Or do both passes at once
-python scripts/scan_optimized.py --include ~/Documents --out results
+python3 scripts/scan_optimized.py --include ~/Documents --out results
 ```
 
 ### Traditional Single-Pass Scanner
 ```bash
 # Basic scan
-python scripts/scan.py --include ~/Documents --out results
+python3 scripts/scan.py --include ~/Documents --out results
 
 # With date filtering
-python scripts/scan.py --include ~/Documents --modified-since 2024-01-01 --out results
+python3 scripts/scan.py --include ~/Documents --modified-since 2024-01-01 --out results
 
 # With Edgar mode (for authentic 80s scanning experience)
-python scripts/scan.py --include ~/Documents --edgar --out results
+python3 scripts/scan.py --include ~/Documents --edgar --out results
 ```
 
 ### Spotlight Integration (macOS)
 ```bash
 # Use macOS Spotlight to build file list first (much faster)
-./scripts/build_paths.sh  # Creates /tmp/paths.txt
-python scripts/scan.py --path-list /tmp/paths.txt --out results
+bash scripts/build_paths.sh  # Creates /tmp/paths.txt on macOS
+python3 scripts/scan.py --path-list /tmp/paths.txt --out results
 ```
 
 ## Configuration
@@ -160,10 +160,10 @@ The scanner can estimate time investment in creative files:
 ### Email and Calendar Integration
 ```bash
 # Scan exported email (.mbox files)
-python scripts/scan.py --mbox ~/Downloads/Inbox.mbox --out results
+python3 scripts/scan.py --mbox ~/Downloads/Inbox.mbox --out results
 
-# Scan calendar exports (.ics files)  
-python scripts/scan.py --ics ~/Downloads/calendar.ics --out results
+# Scan calendar exports (.ics files)
+python3 scripts/scan.py --ics ~/Downloads/calendar.ics --out results
 ```
 
 ## Output Files
@@ -200,7 +200,7 @@ Interactive dashboard with:
 
 ## System Requirements
 
-- Python 3.8+
+- Python 3.8+ (use the system `python3` on macOS or install the latest from python.org/Homebrew)
 - macOS, Linux, or Windows
 - For Edgar GUI: pygame for authentic sounds
 - For large scans: 4GB+ RAM recommended
@@ -210,10 +210,10 @@ Interactive dashboard with:
 ### Edgar GUI Won't Start
 ```bash
 # Install pygame for sounds
-pip install pygame
+python3 -m pip install pygame
 
 # Run without sounds if needed
-python scripts/edgar_gui.py  # Audio will auto-disable if pygame unavailable
+python3 scripts/edgar_gui.py  # Audio will auto-disable if pygame unavailable
 ```
 
 ### No Files Found
@@ -233,8 +233,8 @@ python scripts/edgar_gui.py  # Audio will auto-disable if pygame unavailable
 *"This tool is like, way more useful than it has any right to be."* - Strong Bad
 
 Ready to find some academic evidence? Choose your weapon:
-- 🎮 **Edgar GUI**: `python scripts/edgar_gui.py` 
-- ⚡ **Optimized**: `python scripts/scan_optimized.py --help`
-- 🖥️ **Classic**: `python scripts/scan.py --help`
+- 🎮 **Edgar GUI**: `python3 scripts/edgar_gui.py`
+- ⚡ **Optimized**: `python3 scripts/scan_optimized.py --help`
+- 🖥️ **Classic**: `python3 scripts/scan.py --help`
 
 


### PR DESCRIPTION
## Summary
- update README quick setup and usage examples to consistently use python3/pip3 commands for macOS
- add mac-specific notes for running setup scripts and clarify Python 3 requirement in system requirements

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d70d0bd5888322a06c5896443309c4