### PR TITLE
Add macOS Edgar bundle build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ python3 scripts/edgar_gui.py
 # 5. Enjoy authentic 80s computer sounds
 ```
 
+### Build a macOS App Bundle
+
+Need a self-contained app for macOS that includes the GUI, scan scripts, and retro sound effects? Use the PyInstaller setup that lives in `packaging/macos/`.
+
+```bash
+# Run this on macOS – it creates a dedicated build virtualenv
+scripts/build_edgar_macos.sh
+
+# After the build completes
+open dist/Edgar.app            # Launch the bundled GUI
+```
+
+The bundle includes all of the supporting scan scripts, configuration, and pygame assets. When you launch the packaged app, Edgar writes results to `~/EdgarEvidence/results` so the reports stick around outside the temporary app bundle.
+
 ### Two-Pass Command Line
 ```bash
 # Quick metadata-only scan

--- a/packaging/macos/edgar_gui.spec
+++ b/packaging/macos/edgar_gui.spec
@@ -1,0 +1,81 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import pathlib
+from PyInstaller.building.build_main import Analysis, PYZ, EXE, COLLECT, BUNDLE
+from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.building.datastruct import Tree
+
+block_cipher = None
+
+project_root = pathlib.Path(__file__).resolve().parents[1]
+scripts_dir = project_root / "scripts"
+
+# Core data directories that the scanner relies on.
+config_tree = Tree(str(project_root / "config"), prefix="config", excludes=["*.pyc", "__pycache__"])
+examples_tree = Tree(str(project_root / "examples"), prefix="examples", excludes=["*.pyc", "__pycache__"])
+# Bundle every script so that subprocess calls (scan.py, report.py, etc.) are available.
+script_tree = Tree(str(scripts_dir), prefix="embedded_scripts", excludes=["*.pyc", "__pycache__"])
+
+hiddenimports = collect_submodules("pygame") + [
+    "numpy",
+    "tkinter",
+    "tkinter.filedialog",
+    "tkinter.messagebox",
+    "tkinter.ttk",
+]
+
+datas = collect_data_files("pygame")
+datas += config_tree.toc
+datas += examples_tree.toc
+datas += script_tree.toc
+
+a = Analysis(
+    [str(scripts_dir / "edgar_gui.py")],
+    pathex=[str(scripts_dir)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Edgar",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="Edgar",
+)
+app = BUNDLE(
+    coll,
+    name="Edgar.app",
+    icon=None,
+    bundle_identifier="com.academicevidence.edgar",
+)

--- a/scripts/build_edgar_macos.sh
+++ b/scripts/build_edgar_macos.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${OSTYPE:-}" != darwin* ]]; then
+  echo "[edgar-build] This script must be run on macOS." >&2
+  exit 1
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${PROJECT_ROOT}/.edgar-build-venv"
+
+python3 -m venv "${VENV_DIR}"
+source "${VENV_DIR}/bin/activate"
+
+pip install --upgrade pip wheel
+pip install -r "${PROJECT_ROOT}/requirements.txt" pyinstaller
+
+pyinstaller --clean --noconfirm "${PROJECT_ROOT}/packaging/macos/edgar_gui.spec"
+
+echo "\n[edgar-build] Build complete!"
+echo "[edgar-build] The macOS app is located at: ${PROJECT_ROOT}/dist/Edgar.app"
+echo "[edgar-build] You can move Edgar.app into /Applications for easy access."


### PR DESCRIPTION
## Summary
- add a PyInstaller spec and build script for creating a self-contained Edgar macOS app bundle
- update the GUI so it can locate bundled scripts, use the embedded interpreter, and write scan results to a persistent directory when frozen
- document the macOS app build workflow in the README

## Testing
- python3 -m compileall scripts/edgar_gui.py packaging/macos/edgar_gui.spec

------
https://chatgpt.com/codex/tasks/task_e_68d710071388832282e9fac1f602a06d