### PR TITLE
Fix 8-bit beep buffer contiguity

### DIFF
--- a/scripts/edgar_gui_8bit_robust.py
+++ b/scripts/edgar_gui_8bit_robust.py
@@ -158,7 +158,7 @@ class Edgar8BitGUIRobust:
                     wave = np.sin(2 * np.pi * frequency * t) * 0.3
                 
                 wave = (wave * 32767).astype(np.int16)
-                stereo_wave = np.array([wave, wave]).T
+                stereo_wave = np.ascontiguousarray(np.column_stack((wave, wave)))
                 sound = pygame.sndarray.make_sound(stereo_wave)
                 sound.play()
                 


### PR DESCRIPTION
## Summary
- build the 8-bit beep stereo buffer with `np.column_stack` and wrap it with `np.ascontiguousarray` to satisfy pygame

## Testing
- SDL_AUDIODRIVER=dummy python - <<'PY'
import pygame, numpy as np
pygame.mixer.init(frequency=22050, size=-16, channels=2, buffer=512)
frequency=800; duration=100
sample_rate=22050
frames=int(duration*sample_rate/1000)
t=np.linspace(0, duration/1000, frames)
wave=np.sign(np.sin(2*np.pi*frequency*t))*0.3
wave=(wave*32767).astype(np.int16)
stereo_wave=np.ascontiguousarray(np.column_stack((wave, wave)))
pygame.sndarray.make_sound(stereo_wave).play()
pygame.time.delay(200)
pygame.mixer.quit()
PY

------
https://chatgpt.com/codex/tasks/task_e_68d7695337fc832284edf5642e646686