### PR TITLE
Replace YAML dependency with JSON rules

### DIFF
--- a/ae_finder/__init__.py
+++ b/ae_finder/__init__.py
@@ -1,5 +1,6 @@
 """Core Academic Evidence Finder package."""
 
+from .config_loader import UnsupportedConfigFormatError, load_rules_config
 from .provenance import ProvenanceScorer
 
-__all__ = ["ProvenanceScorer"]
+__all__ = ["ProvenanceScorer", "load_rules_config", "UnsupportedConfigFormatError"]

--- a/ae_finder/config_loader.py
+++ b/ae_finder/config_loader.py
@@ -1,0 +1,46 @@
+"""Configuration loading utilities for the Academic Evidence Finder."""
+
+from __future__ import annotations
+
+import json
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class UnsupportedConfigFormatError(RuntimeError):
+    """Raised when a configuration file uses an unsupported format."""
+
+
+def load_rules_config(path: str | Path) -> Mapping[str, Any]:
+    """Load the rules configuration from JSON or YAML.
+
+    JSON is preferred because it keeps the command-line tools free from external
+    dependencies. YAML remains supported for backward compatibility when the
+    optional :mod:`PyYAML` package is available. The loader produces a friendly
+    error message when a YAML file is supplied but the dependency is missing.
+    """
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path_obj}")
+
+    suffix = path_obj.suffix.lower()
+    text = path_obj.read_text(encoding="utf-8")
+
+    if suffix == ".json":
+        return json.loads(text)
+
+    if suffix in {".yml", ".yaml"}:
+        if find_spec("yaml") is None:
+            raise ModuleNotFoundError(
+                "PyYAML is required to read YAML configuration files. "
+                "Install it with 'pip install PyYAML' or convert the file to JSON."
+            )
+        import yaml  # type: ignore[import-untyped]
+
+        return yaml.safe_load(text)
+
+    raise UnsupportedConfigFormatError(
+        f"Unsupported configuration format: {path_obj.suffix or '(no extension)'}"
+    )

--- a/config/rules.json
+++ b/config/rules.json
@@ -1,0 +1,372 @@
+{
+  "categories": {
+    "Teaching": {
+      "Syllabi": {
+        "any": [
+          "\\bsyllabus\\b",
+          "\\boffice hours\\b",
+          "\\bcredit hours\\b",
+          "\\bprerequisites?\\b",
+          "\\bgrading (policy|scale)\\b",
+          "\\bcourse (schedule|outline)\\b",
+          "\\blearning outcomes?\\b"
+        ]
+      },
+      "Assignments": {
+        "any": [
+          "\\bassignment\\b",
+          "\\bdue date\\b",
+          "\\bsubmission\\b",
+          "\\bplagiarism\\b",
+          "\\brubric\\b",
+          "\\bpoints?\\b",
+          "\\b(LMS|Canvas|Blackboard|D2L|Moodle)\\b"
+        ]
+      },
+      "Exams": {
+        "any": [
+          "\\bexam\\b",
+          "\\bmidterm\\b",
+          "\\bfinal exam\\b",
+          "\\bquiz\\b",
+          "\\bproctor\\b"
+        ]
+      }
+    },
+    "Service": {
+      "Conference": {
+        "any": [
+          "call for papers",
+          "\\bproposal\\b",
+          "\\bproceedings\\b",
+          "\\bposter\\b",
+          "\\bpresentation\\b"
+        ]
+      }
+    },
+    "Scholarship": {
+      "Musical_Compositions": {
+        "any": [
+          "original composition",
+          "commissioned piece",
+          "premiere performance",
+          "world premiere",
+          "regional premiere",
+          "musical work",
+          "concert piece",
+          "chamber work",
+          "solo piece",
+          "ensemble piece",
+          "wind band composition",
+          "concert band piece",
+          "marching band arrangement",
+          "ceremonial music",
+          "processional",
+          "fanfare",
+          "overture"
+        ]
+      },
+      "Music_Arrangements": {
+        "any": [
+          "musical arrangement",
+          "transcription",
+          "adaptation",
+          "orchestration",
+          "re-orchestration",
+          "instrumentation",
+          "wind band arrangement",
+          "concert band arrangement",
+          "marching band arrangement",
+          "pep band arrangement",
+          "jazz arrangement",
+          "popular music arrangement",
+          "traditional arrangement",
+          "folk song arrangement",
+          "hymn arrangement",
+          "patriotic arrangement"
+        ]
+      },
+      "Drill_Design_Works": {
+        "any": [
+          "drill design",
+          "field show design",
+          "marching show",
+          "halftime show",
+          "competition show",
+          "parade formation",
+          "ceremonial formation",
+          "visual design",
+          "3D drill animation",
+          "field choreography",
+          "formation design",
+          "drill innovation",
+          "visual effect",
+          "prop integration",
+          "color guard integration"
+        ]
+      },
+      "Music_Technology_Research": {
+        "any": [
+          "music notation software",
+          "digital music creation",
+          "MIDI technology",
+          "music software development",
+          "audio production",
+          "music app development",
+          "educational technology",
+          "music learning software",
+          "rehearsal technology",
+          "performance technology",
+          "music distribution",
+          "streaming optimization"
+        ]
+      }
+    },
+    "Debug": {
+      "AnyText": {
+        "any": [
+          "\\w{3,}"
+        ]
+      }
+    },
+    "Research": {
+      "IRB": {
+        "any": [
+          "\\bIRB\\b",
+          "institutional review board",
+          "\\bprotocol\\b",
+          "\\binformed consent\\b",
+          "\\bqualtrics\\b"
+        ]
+      },
+      "Publications": {
+        "any": [
+          "\\babstract\\b",
+          "\\bmethodology\\b",
+          "\\bliterature review\\b",
+          "\\bresults\\b",
+          "\\bdiscussion\\b",
+          "\\breferences\\b",
+          "doi:\\s*10\\.",
+          "arXiv:\\s*\\d{4}\\.\\d+"
+        ]
+      },
+      "Grants": {
+        "any": [
+          "\\bNSF\\b",
+          "\\bNIH\\b",
+          "grant proposal",
+          "budget justification",
+          "\\bbiosketch\\b",
+          "current and pending"
+        ]
+      }
+    },
+    "Administration": {
+      "Assessment": {
+        "any": [
+          "\\bassessment\\b",
+          "\\baccreditation\\b",
+          "\\bHLC\\b",
+          "\\bcurriculum committee\\b",
+          "\\bprogram review\\b"
+        ]
+      }
+    }
+  },
+  "file_filters": {
+    "include_extensions": [
+      ".pdf",
+      ".docx",
+      ".pptx",
+      ".txt",
+      ".doc",
+      ".rtf",
+      ".odt",
+      ".pages",
+      ".key",
+      ".odp",
+      ".xlsx",
+      ".xls",
+      ".csv",
+      ".ods",
+      ".numbers",
+      ".md",
+      ".tex",
+      ".html",
+      ".htm",
+      ".xml",
+      ".mus",
+      ".musx",
+      ".sib",
+      ".ftm",
+      ".ftmx",
+      ".musicxml",
+      ".mxl",
+      ".xml",
+      ".3dj",
+      ".3dz",
+      ".3da",
+      ".prod",
+      ".mid",
+      ".midi",
+      ".mp3",
+      ".wav",
+      ".aif",
+      ".m4a"
+    ],
+    "exclude_dirs": [
+      ".git",
+      "node_modules",
+      "__pycache__",
+      ".venv",
+      ".DS_Store",
+      "Thumbs.db",
+      "temp",
+      "tmp",
+      "cache",
+      "backup",
+      "archive",
+      "old",
+      "deleted",
+      "trash",
+      "Finale Backups",
+      "Sibelius Backups",
+      "Pyware Backups"
+    ]
+  },
+  "scoring": {
+    "per_hit_points": 1,
+    "cap_per_file": 25,
+    "category_weights": {
+      "Teaching": 1.0,
+      "Service": 1.1,
+      "Scholarship": 1.3
+    },
+    "bonus_keywords": {
+      "NASM": 3,
+      "accreditation": 3,
+      "tenure": 5,
+      "promotion": 5,
+      "peer review": 3,
+      "published": 4,
+      "conference presentation": 4,
+      "grant award": 5,
+      "fellowship": 4,
+      "sabbatical": 4,
+      "CBDNA": 3,
+      "NAfME": 3,
+      "original composition": 8,
+      "commissioned work": 8,
+      "world premiere": 6,
+      "premiere performance": 5,
+      "musical arrangement": 4,
+      "transcription": 3,
+      "orchestration": 4,
+      "drill design": 6,
+      "field show design": 7,
+      "halftime show": 5,
+      "marching band show": 5,
+      "3D animation": 4,
+      "Pyware": 3,
+      "Finale": 2,
+      "Sibelius": 2,
+      "music notation": 3,
+      "MusicXML": 2,
+      "MIDI": 2,
+      "guest conductor": 4,
+      "masterclass": 3,
+      "clinic": 3,
+      "adjudicator": 3,
+      "festival judge": 3,
+      "honor band": 4,
+      "all-state": 4,
+      "national conference": 5,
+      "international conference": 6,
+      "keynote": 7,
+      "plenary": 6,
+      "editorial board": 5,
+      "manuscript review": 4,
+      "external review": 4,
+      "grant funded": 6,
+      "Colorado Mesa": 2,
+      "CMEA": 3,
+      "Western Division": 4
+    }
+  },
+  "file_processing": {
+    "proprietary_formats": [
+      ".mus",
+      ".musx",
+      ".sib",
+      ".3dj",
+      ".3dz",
+      ".3da",
+      ".prod"
+    ],
+    "filename_analysis": {
+      "composition_indicators": [
+        "original",
+        "composition",
+        "op\\s*\\d+",
+        "mvt\\s*\\d+",
+        "no\\s*\\d+"
+      ],
+      "arrangement_indicators": [
+        "arr\\.",
+        "arranged",
+        "arrangement",
+        "transcription",
+        "adaptation"
+      ],
+      "drill_indicators": [
+        "drill",
+        "show",
+        "halftime",
+        "field",
+        "formation",
+        "animation"
+      ],
+      "version_indicators": [
+        "v\\d+",
+        "version",
+        "draft",
+        "final",
+        "revised",
+        "\\d{4}[-_]\\d{2}[-_]\\d{2}"
+      ],
+      "project_indicators": [
+        "\\b20\\d{2}\\b",
+        "fall|spring|summer",
+        "semester",
+        "concert",
+        "recital",
+        "festival"
+      ]
+    }
+  },
+  "effort_analysis": {
+    "work_session_max_gap_hours": 4,
+    "minimum_work_session_minutes": 5,
+    "typical_save_intervals": {
+      ".musx": 15,
+      ".mus": 20,
+      ".sib": 15,
+      ".3dj": 10,
+      ".3dz": 30,
+      ".pdf": 30,
+      ".docx": 10,
+      ".pptx": 20
+    },
+    "complexity_multipliers": {
+      "size_small": 1.0,
+      "size_medium": 1.3,
+      "size_large": 1.8,
+      "size_xlarge": 2.5,
+      "span_single": 1.0,
+      "span_short": 1.2,
+      "span_medium": 1.5,
+      "span_long": 2.0
+    }
+  }
+}

--- a/scripts/scan.py
+++ b/scripts/scan.py
@@ -1,5 +1,5 @@
 
-import argparse, os, re, yaml, mailbox, json, time
+import argparse, os, re, mailbox, json, time
 from pathlib import Path
 from datetime import datetime, timezone
 from dateutil import parser as dtparse
@@ -10,6 +10,7 @@ from collections import Counter
 
 from report import write_csv, write_summary, write_html
 from extractors import extract_text
+from ae_finder import load_rules_config
 
 # ---------- helpers ----------
 
@@ -56,8 +57,7 @@ def write_progress(outdir, stage, n, total, started_ts):
 # ---------- rules ----------
 
 def load_rules(path):
-    with open(path, "r") as f:
-        cfg = yaml.safe_load(f)
+    cfg = load_rules_config(path)
     compiled = {}
     for cat, subs in cfg["categories"].items():
         compiled[cat] = {}
@@ -191,7 +191,7 @@ def main():
     ap.add_argument("--ics-file", help="File listing ICS paths")
     ap.add_argument("--mbox", nargs="*", help="MBOX files")
     ap.add_argument("--mbox-file", help="File listing MBOX paths")
-    ap.add_argument("--rules", default=str(Path(__file__).resolve().parents[1] / "config" / "rules.yml"))
+    ap.add_argument("--rules", default=str(Path(__file__).resolve().parents[1] / "config" / "rules.json"))
     ap.add_argument("--out", default="out", help="Output directory")
     ap.add_argument("--modified-since", help="YYYY-MM-DD")
     ap.add_argument("--modified-until", help="YYYY-MM-DD")

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,47 @@
+"""Tests for configuration loading utilities."""
+
+from __future__ import annotations
+
+import json
+from importlib import util as importlib_util
+from pathlib import Path
+
+import pytest
+
+from ae_finder import UnsupportedConfigFormatError, load_rules_config
+
+def write_temp_file(tmp_path: Path, name: str, contents: str) -> Path:
+    path = tmp_path / name
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_load_rules_config_from_json(tmp_path: Path) -> None:
+    payload = {"categories": {"Example": {"Any": {"any": ["pattern"]}}}}
+    rules_path = write_temp_file(tmp_path, "rules.json", json.dumps(payload))
+
+    loaded = load_rules_config(rules_path)
+
+    assert loaded["categories"]["Example"]["Any"]["any"] == ["pattern"]
+
+
+def test_load_rules_config_from_yaml_without_dependency(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    yaml_contents = "categories:\n  Example:\n    Any:\n      any:\n        - pattern\n"
+    rules_path = write_temp_file(tmp_path, "rules.yml", yaml_contents)
+
+    def fake_find_spec(name: str, package: str | None = None) -> None:
+        if name == "yaml":
+            return None
+        return importlib_util.find_spec(name, package)
+
+    monkeypatch.setattr("ae_finder.config_loader.find_spec", fake_find_spec)
+
+    with pytest.raises(ModuleNotFoundError):
+        load_rules_config(rules_path)
+
+
+def test_load_rules_config_unsupported_extension(tmp_path: Path) -> None:
+    config_path = write_temp_file(tmp_path, "rules.txt", "noop")
+
+    with pytest.raises(UnsupportedConfigFormatError):
+        load_rules_config(config_path)


### PR DESCRIPTION
## Summary
- add a shared configuration loader that prefers JSON and gracefully handles optional YAML support
- convert the default rules configuration to JSON and update both scanners to use it
- cover the new loader with tests and export it from the package for reuse

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7775ddc648322bbcc08f2ead687b6