### PR TITLE
Handle missing tqdm dependency

### DIFF
--- a/ae_finder/__init__.py
+++ b/ae_finder/__init__.py
@@ -1,5 +1,6 @@
 """Core Academic Evidence Finder package."""
 
+from .config_loader import UnsupportedConfigFormatError, load_rules_config
 from .provenance import ProvenanceScorer
 
-__all__ = ["ProvenanceScorer"]
+__all__ = ["ProvenanceScorer", "load_rules_config", "UnsupportedConfigFormatError"]

--- a/ae_finder/config_loader.py
+++ b/ae_finder/config_loader.py
@@ -1,0 +1,46 @@
+"""Configuration loading utilities for the Academic Evidence Finder."""
+
+from __future__ import annotations
+
+import json
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class UnsupportedConfigFormatError(RuntimeError):
+    """Raised when a configuration file uses an unsupported format."""
+
+
+def load_rules_config(path: str | Path) -> Mapping[str, Any]:
+    """Load the rules configuration from JSON or YAML.
+
+    JSON is preferred because it keeps the command-line tools free from external
+    dependencies. YAML remains supported for backward compatibility when the
+    optional :mod:`PyYAML` package is available. The loader produces a friendly
+    error message when a YAML file is supplied but the dependency is missing.
+    """
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path_obj}")
+
+    suffix = path_obj.suffix.lower()
+    text = path_obj.read_text(encoding="utf-8")
+
+    if suffix == ".json":
+        return json.loads(text)
+
+    if suffix in {".yml", ".yaml"}:
+        if find_spec("yaml") is None:
+            raise ModuleNotFoundError(
+                "PyYAML is required to read YAML configuration files. "
+                "Install it with 'pip install PyYAML' or convert the file to JSON."
+            )
+        import yaml  # type: ignore[import-untyped]
+
+        return yaml.safe_load(text)
+
+    raise UnsupportedConfigFormatError(
+        f"Unsupported configuration format: {path_obj.suffix or '(no extension)'}"
+    )

--- a/ae_finder/tqdm_compat.py
+++ b/ae_finder/tqdm_compat.py
@@ -1,0 +1,60 @@
+"""Compatibility helpers for optional tqdm dependency."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator, Optional, TypeVar
+
+T = TypeVar("T")
+
+try:  # pragma: no cover - exercised when tqdm is available
+    from tqdm import tqdm as tqdm  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - triggered in minimal installs
+
+    class _DummyTqdm(Iterator[T]):
+        """Minimal tqdm replacement when the real dependency is unavailable."""
+
+        def __init__(
+            self,
+            iterable: Optional[Iterable[T]] = None,
+            *args,
+            total: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            self._iterable = iterable
+            self._iterator = iter(iterable) if iterable is not None else iter(())
+            self.total = total if total is not None else (len(iterable) if hasattr(iterable, "__len__") else None)
+            self.n = 0
+
+        def __iter__(self) -> Iterator[T]:
+            return self
+
+        def __next__(self) -> T:  # Support Iterator protocol directly
+            item = next(self._iterator)
+            self.n += 1
+            return item
+
+        def update(self, n: int = 1) -> None:
+            self.n += n
+
+        def set_description(self, *args, **kwargs) -> None:  # noqa: D401 - passthrough
+            """No-op placeholder for tqdm API compatibility."""
+
+        def set_postfix(self, *args, **kwargs) -> None:
+            pass
+
+        def set_postfix_str(self, *args, **kwargs) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        def __enter__(self) -> "_DummyTqdm":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def tqdm(iterable: Optional[Iterable[T]] = None, *args, **kwargs) -> _DummyTqdm:
+        return _DummyTqdm(iterable, *args, **kwargs)
+
+__all__ = ["tqdm"]

--- a/config/rules.json
+++ b/config/rules.json
@@ -1,0 +1,372 @@
+{
+  "categories": {
+    "Teaching": {
+      "Syllabi": {
+        "any": [
+          "\\bsyllabus\\b",
+          "\\boffice hours\\b",
+          "\\bcredit hours\\b",
+          "\\bprerequisites?\\b",
+          "\\bgrading (policy|scale)\\b",
+          "\\bcourse (schedule|outline)\\b",
+          "\\blearning outcomes?\\b"
+        ]
+      },
+      "Assignments": {
+        "any": [
+          "\\bassignment\\b",
+          "\\bdue date\\b",
+          "\\bsubmission\\b",
+          "\\bplagiarism\\b",
+          "\\brubric\\b",
+          "\\bpoints?\\b",
+          "\\b(LMS|Canvas|Blackboard|D2L|Moodle)\\b"
+        ]
+      },
+      "Exams": {
+        "any": [
+          "\\bexam\\b",
+          "\\bmidterm\\b",
+          "\\bfinal exam\\b",
+          "\\bquiz\\b",
+          "\\bproctor\\b"
+        ]
+      }
+    },
+    "Service": {
+      "Conference": {
+        "any": [
+          "call for papers",
+          "\\bproposal\\b",
+          "\\bproceedings\\b",
+          "\\bposter\\b",
+          "\\bpresentation\\b"
+        ]
+      }
+    },
+    "Scholarship": {
+      "Musical_Compositions": {
+        "any": [
+          "original composition",
+          "commissioned piece",
+          "premiere performance",
+          "world premiere",
+          "regional premiere",
+          "musical work",
+          "concert piece",
+          "chamber work",
+          "solo piece",
+          "ensemble piece",
+          "wind band composition",
+          "concert band piece",
+          "marching band arrangement",
+          "ceremonial music",
+          "processional",
+          "fanfare",
+          "overture"
+        ]
+      },
+      "Music_Arrangements": {
+        "any": [
+          "musical arrangement",
+          "transcription",
+          "adaptation",
+          "orchestration",
+          "re-orchestration",
+          "instrumentation",
+          "wind band arrangement",
+          "concert band arrangement",
+          "marching band arrangement",
+          "pep band arrangement",
+          "jazz arrangement",
+          "popular music arrangement",
+          "traditional arrangement",
+          "folk song arrangement",
+          "hymn arrangement",
+          "patriotic arrangement"
+        ]
+      },
+      "Drill_Design_Works": {
+        "any": [
+          "drill design",
+          "field show design",
+          "marching show",
+          "halftime show",
+          "competition show",
+          "parade formation",
+          "ceremonial formation",
+          "visual design",
+          "3D drill animation",
+          "field choreography",
+          "formation design",
+          "drill innovation",
+          "visual effect",
+          "prop integration",
+          "color guard integration"
+        ]
+      },
+      "Music_Technology_Research": {
+        "any": [
+          "music notation software",
+          "digital music creation",
+          "MIDI technology",
+          "music software development",
+          "audio production",
+          "music app development",
+          "educational technology",
+          "music learning software",
+          "rehearsal technology",
+          "performance technology",
+          "music distribution",
+          "streaming optimization"
+        ]
+      }
+    },
+    "Debug": {
+      "AnyText": {
+        "any": [
+          "\\w{3,}"
+        ]
+      }
+    },
+    "Research": {
+      "IRB": {
+        "any": [
+          "\\bIRB\\b",
+          "institutional review board",
+          "\\bprotocol\\b",
+          "\\binformed consent\\b",
+          "\\bqualtrics\\b"
+        ]
+      },
+      "Publications": {
+        "any": [
+          "\\babstract\\b",
+          "\\bmethodology\\b",
+          "\\bliterature review\\b",
+          "\\bresults\\b",
+          "\\bdiscussion\\b",
+          "\\breferences\\b",
+          "doi:\\s*10\\.",
+          "arXiv:\\s*\\d{4}\\.\\d+"
+        ]
+      },
+      "Grants": {
+        "any": [
+          "\\bNSF\\b",
+          "\\bNIH\\b",
+          "grant proposal",
+          "budget justification",
+          "\\bbiosketch\\b",
+          "current and pending"
+        ]
+      }
+    },
+    "Administration": {
+      "Assessment": {
+        "any": [
+          "\\bassessment\\b",
+          "\\baccreditation\\b",
+          "\\bHLC\\b",
+          "\\bcurriculum committee\\b",
+          "\\bprogram review\\b"
+        ]
+      }
+    }
+  },
+  "file_filters": {
+    "include_extensions": [
+      ".pdf",
+      ".docx",
+      ".pptx",
+      ".txt",
+      ".doc",
+      ".rtf",
+      ".odt",
+      ".pages",
+      ".key",
+      ".odp",
+      ".xlsx",
+      ".xls",
+      ".csv",
+      ".ods",
+      ".numbers",
+      ".md",
+      ".tex",
+      ".html",
+      ".htm",
+      ".xml",
+      ".mus",
+      ".musx",
+      ".sib",
+      ".ftm",
+      ".ftmx",
+      ".musicxml",
+      ".mxl",
+      ".xml",
+      ".3dj",
+      ".3dz",
+      ".3da",
+      ".prod",
+      ".mid",
+      ".midi",
+      ".mp3",
+      ".wav",
+      ".aif",
+      ".m4a"
+    ],
+    "exclude_dirs": [
+      ".git",
+      "node_modules",
+      "__pycache__",
+      ".venv",
+      ".DS_Store",
+      "Thumbs.db",
+      "temp",
+      "tmp",
+      "cache",
+      "backup",
+      "archive",
+      "old",
+      "deleted",
+      "trash",
+      "Finale Backups",
+      "Sibelius Backups",
+      "Pyware Backups"
+    ]
+  },
+  "scoring": {
+    "per_hit_points": 1,
+    "cap_per_file": 25,
+    "category_weights": {
+      "Teaching": 1.0,
+      "Service": 1.1,
+      "Scholarship": 1.3
+    },
+    "bonus_keywords": {
+      "NASM": 3,
+      "accreditation": 3,
+      "tenure": 5,
+      "promotion": 5,
+      "peer review": 3,
+      "published": 4,
+      "conference presentation": 4,
+      "grant award": 5,
+      "fellowship": 4,
+      "sabbatical": 4,
+      "CBDNA": 3,
+      "NAfME": 3,
+      "original composition": 8,
+      "commissioned work": 8,
+      "world premiere": 6,
+      "premiere performance": 5,
+      "musical arrangement": 4,
+      "transcription": 3,
+      "orchestration": 4,
+      "drill design": 6,
+      "field show design": 7,
+      "halftime show": 5,
+      "marching band show": 5,
+      "3D animation": 4,
+      "Pyware": 3,
+      "Finale": 2,
+      "Sibelius": 2,
+      "music notation": 3,
+      "MusicXML": 2,
+      "MIDI": 2,
+      "guest conductor": 4,
+      "masterclass": 3,
+      "clinic": 3,
+      "adjudicator": 3,
+      "festival judge": 3,
+      "honor band": 4,
+      "all-state": 4,
+      "national conference": 5,
+      "international conference": 6,
+      "keynote": 7,
+      "plenary": 6,
+      "editorial board": 5,
+      "manuscript review": 4,
+      "external review": 4,
+      "grant funded": 6,
+      "Colorado Mesa": 2,
+      "CMEA": 3,
+      "Western Division": 4
+    }
+  },
+  "file_processing": {
+    "proprietary_formats": [
+      ".mus",
+      ".musx",
+      ".sib",
+      ".3dj",
+      ".3dz",
+      ".3da",
+      ".prod"
+    ],
+    "filename_analysis": {
+      "composition_indicators": [
+        "original",
+        "composition",
+        "op\\s*\\d+",
+        "mvt\\s*\\d+",
+        "no\\s*\\d+"
+      ],
+      "arrangement_indicators": [
+        "arr\\.",
+        "arranged",
+        "arrangement",
+        "transcription",
+        "adaptation"
+      ],
+      "drill_indicators": [
+        "drill",
+        "show",
+        "halftime",
+        "field",
+        "formation",
+        "animation"
+      ],
+      "version_indicators": [
+        "v\\d+",
+        "version",
+        "draft",
+        "final",
+        "revised",
+        "\\d{4}[-_]\\d{2}[-_]\\d{2}"
+      ],
+      "project_indicators": [
+        "\\b20\\d{2}\\b",
+        "fall|spring|summer",
+        "semester",
+        "concert",
+        "recital",
+        "festival"
+      ]
+    }
+  },
+  "effort_analysis": {
+    "work_session_max_gap_hours": 4,
+    "minimum_work_session_minutes": 5,
+    "typical_save_intervals": {
+      ".musx": 15,
+      ".mus": 20,
+      ".sib": 15,
+      ".3dj": 10,
+      ".3dz": 30,
+      ".pdf": 30,
+      ".docx": 10,
+      ".pptx": 20
+    },
+    "complexity_multipliers": {
+      "size_small": 1.0,
+      "size_medium": 1.3,
+      "size_large": 1.8,
+      "size_xlarge": 2.5,
+      "span_single": 1.0,
+      "span_short": 1.2,
+      "span_medium": 1.5,
+      "span_long": 2.0
+    }
+  }
+}

--- a/scripts/scan.py
+++ b/scripts/scan.py
@@ -1,15 +1,16 @@
 
-import argparse, os, re, yaml, mailbox, json, time
+import argparse, os, re, mailbox, json, time
 from pathlib import Path
 from datetime import datetime, timezone
 from dateutil import parser as dtparse
 from icalendar import Calendar
 from bs4 import BeautifulSoup
-from tqdm import tqdm
+from ae_finder.tqdm_compat import tqdm
 from collections import Counter
 
 from report import write_csv, write_summary, write_html
 from extractors import extract_text
+from ae_finder import load_rules_config
 
 # ---------- helpers ----------
 
@@ -56,8 +57,7 @@ def write_progress(outdir, stage, n, total, started_ts):
 # ---------- rules ----------
 
 def load_rules(path):
-    with open(path, "r") as f:
-        cfg = yaml.safe_load(f)
+    cfg = load_rules_config(path)
     compiled = {}
     for cat, subs in cfg["categories"].items():
         compiled[cat] = {}
@@ -191,7 +191,7 @@ def main():
     ap.add_argument("--ics-file", help="File listing ICS paths")
     ap.add_argument("--mbox", nargs="*", help="MBOX files")
     ap.add_argument("--mbox-file", help="File listing MBOX paths")
-    ap.add_argument("--rules", default=str(Path(__file__).resolve().parents[1] / "config" / "rules.yml"))
+    ap.add_argument("--rules", default=str(Path(__file__).resolve().parents[1] / "config" / "rules.json"))
     ap.add_argument("--out", default="out", help="Output directory")
     ap.add_argument("--modified-since", help="YYYY-MM-DD")
     ap.add_argument("--modified-until", help="YYYY-MM-DD")

--- a/scripts/scan_optimized.py
+++ b/scripts/scan_optimized.py
@@ -8,11 +8,13 @@ Pass 2: Full text extraction and detailed analysis
                                                                   - Strong Bad, probably
 """
 
-import argparse, os, re, yaml, json, time
+import argparse, os, re, json, time
 from pathlib import Path
 from datetime import datetime, timezone
-from tqdm import tqdm
+from ae_finder.tqdm_compat import tqdm
 from collections import Counter, defaultdict
+
+from ae_finder import load_rules_config
 
 class MetadataAnalyzer:
     """Fast metadata-only analysis for initial categorization"""
@@ -138,8 +140,7 @@ class TwoPassScanner:
     """Two-pass scanner: metadata first, then detailed analysis (because efficiency)"""
     
     def __init__(self, config_path):
-        with open(config_path) as f:
-            self.config = yaml.safe_load(f)
+        self.config = load_rules_config(config_path)
         self.metadata_analyzer = MetadataAnalyzer(self.config)
         
     def pass1_metadata_scan(self, file_paths, output_dir):
@@ -392,7 +393,11 @@ def main():
     parser.add_argument("--path-list", help="File with paths to scan")
     parser.add_argument("--include", nargs="*", help="Directories to scan")
     parser.add_argument("--include-file", help="File with directories to scan")  
-    parser.add_argument("--rules", default="config/rules.yml", help="Rules configuration file")
+    parser.add_argument(
+        "--rules",
+        default=str(Path(__file__).resolve().parents[1] / "config" / "rules.json"),
+        help="Rules configuration file",
+    )
     parser.add_argument("--out", default="out", help="Output directory")
     parser.add_argument("--pass1-only", action="store_true", help="Run only metadata analysis (quick survey)")
     parser.add_argument("--categories", nargs="+", default=["teaching", "service", "scholarship"], 
@@ -408,10 +413,9 @@ def main():
     
     # Initialize scanner
     scanner = TwoPassScanner(args.rules)
-    
+
     # Load configuration for file filters
-    with open(args.rules) as f:
-        config = yaml.safe_load(f)
+    config = load_rules_config(args.rules)
     
     include_exts = set([e.lower() for e in config["file_filters"]["include_extensions"]])
     if args.only_ext:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,47 @@
+"""Tests for configuration loading utilities."""
+
+from __future__ import annotations
+
+import json
+from importlib import util as importlib_util
+from pathlib import Path
+
+import pytest
+
+from ae_finder import UnsupportedConfigFormatError, load_rules_config
+
+def write_temp_file(tmp_path: Path, name: str, contents: str) -> Path:
+    path = tmp_path / name
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_load_rules_config_from_json(tmp_path: Path) -> None:
+    payload = {"categories": {"Example": {"Any": {"any": ["pattern"]}}}}
+    rules_path = write_temp_file(tmp_path, "rules.json", json.dumps(payload))
+
+    loaded = load_rules_config(rules_path)
+
+    assert loaded["categories"]["Example"]["Any"]["any"] == ["pattern"]
+
+
+def test_load_rules_config_from_yaml_without_dependency(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    yaml_contents = "categories:\n  Example:\n    Any:\n      any:\n        - pattern\n"
+    rules_path = write_temp_file(tmp_path, "rules.yml", yaml_contents)
+
+    def fake_find_spec(name: str, package: str | None = None) -> None:
+        if name == "yaml":
+            return None
+        return importlib_util.find_spec(name, package)
+
+    monkeypatch.setattr("ae_finder.config_loader.find_spec", fake_find_spec)
+
+    with pytest.raises(ModuleNotFoundError):
+        load_rules_config(rules_path)
+
+
+def test_load_rules_config_unsupported_extension(tmp_path: Path) -> None:
+    config_path = write_temp_file(tmp_path, "rules.txt", "noop")
+
+    with pytest.raises(UnsupportedConfigFormatError):
+        load_rules_config(config_path)


### PR DESCRIPTION
## Summary
- add an internal tqdm compatibility shim so the scanners work without the optional dependency
- update both scanning entry points to consume the compatibility layer instead of importing tqdm directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7775ddc648322bbcc08f2ead687b6