### PR TITLE
Allow skipping optional sound dependencies during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Scan your computer for artifacts that support **Teaching, Service, Scholarship**
 python3 scripts/evidence_finder_app.py
 ```
 
+Want the optional retro sound effects? Re-run setup with the `--with-sound`
+flag to install `pygame` and `numpy` from `requirements-optional.txt`:
+
+```bash
+./setup_app.sh --with-sound
+```
+
 ### Command line
 ```bash
 python3 -m venv .venv && source .venv/bin/activate

--- a/packaging/macos/evidence_finder_app.spec
+++ b/packaging/macos/evidence_finder_app.spec
@@ -16,7 +16,6 @@ examples_tree = Tree(str(project_root / "examples"), prefix="examples", excludes
 script_tree = Tree(str(scripts_dir), prefix="embedded_scripts", excludes=["*.pyc", "__pycache__"])
 
 hiddenimports = [
-    "numpy",
     "tkinter",
     "tkinter.filedialog",
     "tkinter.messagebox",

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,3 @@
+# Optional extras for the desktop application's sound effects.
+pygame==2.6.1
+numpy>=1.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ lxml==5.2.2
 icalendar==5.0.13
 python-dateutil==2.9.0
 
-# Edgar GUI with authentic retro sound effects
-pygame==2.6.1
-numpy>=1.21.0  # For clean sine wave audio generation
+# Optional desktop sound extras live in requirements-optional.txt
+# pygame==2.6.1
+# numpy>=1.21.0  # For clean sine wave audio generation
 
 # For the enhanced GUI (if we go beyond basic tkinter)
 # Pillow==10.4.0  # Uncomment if we need image processing for GUI

--- a/setup_app.sh
+++ b/setup_app.sh
@@ -3,6 +3,28 @@
 
 set -euo pipefail
 
+install_sound_extras=false
+
+while (( "$#" )); do
+    case "$1" in
+        --with-sound)
+            install_sound_extras=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--with-sound]"
+            echo
+            echo "  --with-sound   Install optional pygame/numpy dependencies for sound effects"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: $0 [--with-sound]" >&2
+            exit 1
+            ;;
+    esac
+done
+
 echo "Preparing Academic Evidence Finder..."
 
 if [[ ! -f "requirements.txt" ]]; then
@@ -20,6 +42,17 @@ source .venv/bin/activate
 echo "Installing Python dependencies..."
 python3 -m pip install --upgrade pip
 pip install -r requirements.txt
+
+if [[ "$install_sound_extras" == true ]]; then
+    if [[ -f "requirements-optional.txt" ]]; then
+        echo "Installing optional sound dependencies..."
+        pip install -r requirements-optional.txt
+    else
+        echo "requirements-optional.txt not found; skipping optional installs." >&2
+    fi
+else
+    echo "Skipping optional pygame/numpy dependencies. Use --with-sound to include them."
+fi
 
 echo "Marking primary scripts as executable..."
 chmod +x scripts/evidence_finder_app.py scripts/scan.py scripts/scan_optimized.py


### PR DESCRIPTION
## Summary
- add a `--with-sound` flag to `setup_app.sh` so pygame/numpy install only when requested and default runs skip them
- document the optional flag and move the sound libraries into a separate requirements file
- update the macOS bundle spec now that numpy is optional

## Testing
- ./setup_app.sh
- ./setup_app.sh --with-sound

------
https://chatgpt.com/codex/tasks/task_e_68d77e00ec888322892ce043e41fee5f